### PR TITLE
Avoid crashing when a message without text is received

### DIFF
--- a/src/main/java/TalkBot.java
+++ b/src/main/java/TalkBot.java
@@ -18,7 +18,9 @@ public class TalkBot {
         TelegramBot telegramBot = new TelegramBot("976951878:AAETlyNbC0ocEilDj...");
         telegramBot.setUpdatesListener(updates -> {
             updates.forEach(update -> {
-                if (update.message() != null && update.message().text().equals("/sayHi")) {
+                if (update.message() != null
+                        && update.message().text() != null
+                        && update.message().text().equals("/sayHi")) {
                     sayHi(telegramBot, update.message());
                     return;
                 }

--- a/src/main/kotlin/BotDsl.kt
+++ b/src/main/kotlin/BotDsl.kt
@@ -32,7 +32,9 @@ class CommandHandler(
 ) : UpdateHandler {
 
     override fun checkUpdate(update: Update): Boolean =
-        update.message() != null && update.message().text().startsWith("/$commandName")
+        update.message() != null
+                && update.message().text() != null
+                && update.message().text().startsWith("/$commandName")
 
     override fun handle(bot: Bot, update: Update) {
         val command = update.message()


### PR DESCRIPTION
The current code was not considering receiving messages without text and the bot was crashing in that case. That's what this PR fixes